### PR TITLE
ci: novos workflows e organização de arquivos

### DIFF
--- a/.github/workflows/advanced-check.yml
+++ b/.github/workflows/advanced-check.yml
@@ -1,0 +1,41 @@
+name: 'Verificação avançada de código'
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      DATABASE_NAME: escola-ti_db
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      NODEMAILER_TEST_HOST: ${{ secrets.NODEMAILER_TEST_HOST }}
+      NODEMAILER_TEST_EMAIL: ${{ secrets.NODEMAILER_TEST_EMAIL }}
+      NODEMAILER_TEST_PASS: ${{ secrets.NODEMAILER_TEST_PASS }}
+      NODEMAILER_USER: ${{ secrets.NODEMAILER_USER }}
+      NODEMAILER_PASS: ${{ secrets.NODEMAILER_PASS }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Subir o Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.12.2'
+
+      - name: Instalar as dependências
+        run: npm install
+
+      - name: Buildar a aplicação
+        run: docker compose build
+
+      - name: Subir a aplicação
+        run: docker compose up -d
+
+      - name: Rodar os testes E2E
+        run: npm run test:e2e
+
+      - name: Parar a aplicação
+        run: docker compose down

--- a/.github/workflows/advanced-check.yml
+++ b/.github/workflows/advanced-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-    
 
 jobs:
   advanced-check:

--- a/.github/workflows/advanced-check.yml
+++ b/.github/workflows/advanced-check.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     branches:
       - 'main'
+    
 
 jobs:
-  check:
+  advanced-check:
     runs-on: ubuntu-latest
     env:
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
@@ -33,6 +34,9 @@ jobs:
 
       - name: Subir a aplicação
         run: docker compose up -d
+
+      - name: Deploy das migrações
+        run: npx prisma migrate deploy
 
       - name: Rodar os testes E2E
         run: npm run test:e2e

--- a/.github/workflows/basic-check.yml
+++ b/.github/workflows/basic-check.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 jobs:
-  check:
+  basic-check:
     runs-on: ubuntu-latest
     env:
       JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/.github/workflows/basic-check.yml
+++ b/.github/workflows/basic-check.yml
@@ -15,6 +15,8 @@ jobs:
       NODEMAILER_TEST_HOST: ${{ secrets.NODEMAILER_TEST_HOST }}
       NODEMAILER_TEST_EMAIL: ${{ secrets.NODEMAILER_TEST_EMAIL }}
       NODEMAILER_TEST_PASS: ${{ secrets.NODEMAILER_TEST_PASS }}
+      NODEMAILER_USER: ${{ secrets.NODEMAILER_USER }}
+      NODEMAILER_PASS: ${{ secrets.NODEMAILER_PASS }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,47 @@
+name: 'Buildar o artefato da imagem Docker'
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  artifact:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
+      PORT: 3000
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      DATABASE_NAME: escola-ti_db
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      NODEMAILER_TEST_HOST: ${{ secrets.NODEMAILER_TEST_HOST }}
+      NODEMAILER_TEST_EMAIL: ${{ secrets.NODEMAILER_TEST_EMAIL }}
+      NODEMAILER_TEST_PASS: ${{ secrets.NODEMAILER_TEST_PASS }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup Docker Build
+        uses: docker/setup-buildx-action@v2
+
+      - name: Instalar Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
+      - name: Buildar imagem Docker
+        run: |
+          docker compose build
+
+      - name: Criar diretório de artefatos
+        run: |
+          mkdir -p artefatos
+
+      - name: Salvar imagem Docker como artefato
+        run: |
+          docker save -o artefatos/cafe-com-type.tar renancesu/cafe-com-type
+
+      - name: Upload do artefato
+        uses: actions/upload-artifact@v4
+        with:
+          name: cafe-com-type
+          path: ./artefatos/cafe-com-type.tar

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,9 +1,12 @@
 name: 'Buildar o artefato da imagem Docker'
 
 on:
-  pull_request:
+  workflow_run:
+    workflows: ["Verificação avançada de código"]
     branches:
-      - main
+      - 'main'
+    types:
+      - completed
 
 jobs:
   artifact:
@@ -17,6 +20,8 @@ jobs:
       NODEMAILER_TEST_HOST: ${{ secrets.NODEMAILER_TEST_HOST }}
       NODEMAILER_TEST_EMAIL: ${{ secrets.NODEMAILER_TEST_EMAIL }}
       NODEMAILER_TEST_PASS: ${{ secrets.NODEMAILER_TEST_PASS }}
+      NODEMAILER_USER: ${{ secrets.NODEMAILER_USER }}
+      NODEMAILER_PASS: ${{ secrets.NODEMAILER_PASS }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,12 +1,9 @@
 name: 'Buildar o artefato da imagem Docker'
 
 on:
-  workflow_run:
-    workflows: ["Verificação avançada de código"]
+  pull_request:
     branches:
       - 'main'
-    types:
-      - completed
 
 jobs:
   artifact:

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -1,49 +1,15 @@
 name: 'Push para o DockerHub'
 
 on:
-  pull_request:
+  workflow_run:
+    workflows: ['Buildar o artefato da imagem Docker']
     branches:
       - main
+    types:
+      - completed
 
 jobs:
-  artifact:
-    runs-on: ubuntu-latest
-    env:
-      NODE_ENV: production
-      PORT: 3000
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      DATABASE_NAME: escola-ti_db
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: setup Docker Build
-        uses: docker/setup-buildx-action@v2
-
-      - name: Instalar Docker Compose
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
-
-      - name: Buildar imagem Docker
-        run: |
-          docker compose build
-
-      - name: Criar diretório de artefatos
-        run: |
-          mkdir -p artefatos
-
-      - name: Salvar imagem Docker como artefato
-        run: |
-          docker save -o artefatos/cafe-com-type.tar renancesu/cafe-com-type
-
-      - name: Upload do artefato
-        uses: actions/upload-artifact@v4
-        with:
-          name: cafe-com-type
-          path: ./artefatos/cafe-com-type.tar
   dockerhub:
-    needs: artifact
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -1,12 +1,9 @@
 name: 'Push para o DockerHub'
 
 on:
-  workflow_run:
-    workflows: ['Buildar o artefato da imagem Docker']
+  push:
     branches:
       - main
-    types:
-      - completed
 
 jobs:
   dockerhub:


### PR DESCRIPTION
- job basic-check para rodar o linter, testes unitários e testes de integração (push pra qualquer branch exceto main)
- job advanced-check para rodar os testes e2e (pull_request pra main)
- job build-artifact para gerar o artefato da imagem docker (pull_request pra main)
- job push-dockerhub enviar o artefato para o dockerhub (push pra main)